### PR TITLE
Add identity rename mechanism

### DIFF
--- a/frontends.go
+++ b/frontends.go
@@ -50,12 +50,16 @@ func HttpHandlerPrelude(config *ConfigHTTP, central *Central, r *http.Request) (
 	if sessioncookie != nil {
 		return central.GetTokenFromSession(sessioncookie.Value)
 	} else {
-		identity, password, eBasic := HttpReadBasicAuth(r)
-		if eBasic != nil {
-			return nil, eBasic
-		} else {
-			return central.GetTokenFromIdentityPassword(identity, password)
-		}
+		return HttpHandlerBasicAuth(central, r)
+	}
+}
+
+func HttpHandlerBasicAuth(central *Central, r *http.Request) (*Token, error) {
+	identity, password, eBasic := HttpReadBasicAuth(r)
+	if eBasic != nil {
+		return nil, eBasic
+	} else {
+		return central.GetTokenFromIdentityPassword(identity, password)
 	}
 }
 

--- a/ldap.go
+++ b/ldap.go
@@ -40,6 +40,10 @@ func (x *ldapAuthenticator) CreateIdentity(identity, password string) error {
 	return ErrUnsupported
 }
 
+func (x *ldapAuthenticator) RenameIdentity(oldIdent, newIdent string) error {
+	return ErrUnsupported
+}
+
 func (x *ldapAuthenticator) GetIdentities() ([]string, error) {
 	return []string{}, ErrUnsupported
 }


### PR DESCRIPTION
Why did we feel justified in adding this complexity?
Currently our users can use any username, but we want to force them to use
email addresses instead. We believe that forcing them to create new
accounts is to disruptive, so we needed to create a mechanism that allows
them to rename their identities.