### PR TITLE
Fix: return cookie with username with consistent case

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -339,7 +339,7 @@ func (x *Central) GetTokenFromIdentityPassword(identity, password string) (*Toke
 		x.Stats.IncrementEmptyIdentities(x.Log)
 		return nil, ErrIdentityEmpty
 	}
-	if eAuth := x.authenticator.Authenticate(identity, password); eAuth == nil {
+	if identity, eAuth := x.authenticator.Authenticate(identity, password); eAuth == nil {
 		if permit, ePermit := x.permitDB.GetPermit(identity); ePermit == nil {
 			t := &Token{}
 			t.Expires = veryFarFuture
@@ -364,8 +364,7 @@ func (x *Central) GetTokenFromIdentityPassword(identity, password string) (*Toke
 // The session key is typically sent to the client as a cookie.
 func (x *Central) Login(identity, password string) (sessionkey string, token *Token, e error) {
 	token = &Token{}
-	token.Identity = identity
-	if e = x.authenticator.Authenticate(identity, password); e == nil {
+	if token.Identity, e = x.authenticator.Authenticate(identity, password); e == nil {
 		x.Log.Printf("Login authentication success (%v)", identity)
 		var permit *Permit
 		if permit, e = x.permitDB.GetPermit(identity); e == nil {

--- a/ldap.go
+++ b/ldap.go
@@ -19,17 +19,19 @@ type ldapAuthenticator struct {
 	con *ldap.LDAPConnection
 }
 
-func (x *ldapAuthenticator) Authenticate(identity, password string) error {
+func (x *ldapAuthenticator) Authenticate(identity, password string) (id string, er error) {
+	id = identity
 	if len(password) == 0 {
 		// Many LDAP servers (or AD) will allow an anonymous BIND.
 		// I've never seen the need for a password-less user authenticated against LDAP.
-		return ErrInvalidPassword
+		er = ErrInvalidPassword
+		return
 	}
 	err := x.con.Bind(identity, password)
 	if err != nil {
-		return NewError(ErrIdentityAuthNotFound, err.Error())
+		er = NewError(ErrIdentityAuthNotFound, err.Error())
 	}
-	return nil
+	return
 }
 
 func (x *ldapAuthenticator) SetPassword(identity, password string) error {


### PR DESCRIPTION
On login return a token where the username has the the original case as on user creation. Also use this case-corrected username in the session table. 

Why not just lowercase everything? We want to keep the option open to support systems that have case-sensitive usernames, even though our own system is case insensitive. 

This also fixes a bug when the user logs in under a username with different case and can't see his/her previously created map themes.