### PR TITLE
Added a getIdentity() method to an AuthUser, to determine which field (of email or us…

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -460,7 +460,7 @@ func (x *Central) authenticate(identity, password string) (UserId, string, error
 		return user.UserId, user.Username, err
 	} else {
 		err = x.userStore.Authenticate(identity, password)
-		return user.UserId, user.Email, err
+		return user.UserId, user.getIdentity(), err
 	}
 }
 

--- a/db.go
+++ b/db.go
@@ -853,3 +853,10 @@ func (x *dummyPermitDB) SetPermit(userId UserId, permit *Permit) error {
 
 func (x *dummyPermitDB) Close() {
 }
+
+func (a *AuthUser) getIdentity() string {
+	if (len(a.Email) == 0) {
+		return a.Username
+	}
+	return a.Email
+}


### PR DESCRIPTION
…ername) to return to request queries. This is viable because we now authenticate against either the username or the email field. We define the identity as either one of these two fields.