### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -110,7 +110,7 @@ func CanonicalizeIdentity(identity string) string {
 	return strings.TrimSpace(strings.ToLower(identity))
 }
 
-// Returns a random string of 'nchars' bytes, sampled uniformly from the given corpus of byte characters.
+// RandomString returns a random string of 'nchars' bytes, sampled uniformly from the given corpus of byte characters.
 func RandomString(nchars int, corpus string) string {
 	rbytes := make([]byte, nchars)
 	rstring := make([]byte, nchars)
@@ -683,12 +683,12 @@ func (x *Central) InvalidateSessionsForIdentity(userId UserId) error {
 	return x.sessionDB.InvalidateSessionsForIdentity(userId)
 }
 
-// Retrieve a Permit.
+// GetPermit retrieves a Permit.
 func (x *Central) GetPermit(userId UserId) (*Permit, error) {
 	return x.permitDB.GetPermit(userId)
 }
 
-// Retrieve all Permits.
+// GetPermits retrieves all Permits.
 func (x *Central) GetPermits() (map[UserId]*Permit, error) {
 	return x.permitDB.GetPermits()
 }
@@ -788,7 +788,7 @@ func (x *Central) ArchiveIdentity(userId UserId) error {
 	return nil
 }
 
-// Get AuthUser object from identity.
+// GetUserFromIdentity gets AuthUser object from identity.
 func (x *Central) GetUserFromIdentity(identity string) (AuthUser, error) {
 	user, e := x.userStore.GetUserFromIdentity(identity)
 	if e == nil {
@@ -799,7 +799,7 @@ func (x *Central) GetUserFromIdentity(identity string) (AuthUser, error) {
 	return AuthUser{}, e
 }
 
-// Get AuthUser object from userid.
+// GetUserFromUserId gets AuthUser object from userid.
 func (x *Central) GetUserFromUserId(userId UserId) (AuthUser, error) {
 	user, e := x.userStore.GetUserFromUserId(userId)
 	if e == nil {
@@ -810,7 +810,7 @@ func (x *Central) GetUserFromUserId(userId UserId) (AuthUser, error) {
 	return AuthUser{}, e
 }
 
-// Get AuthUser full name from userid.
+// GetUserNameFromUserId gets AuthUser full name from userid.
 func (x *Central) GetUserNameFromUserId(userId UserId) string {
 	if userId == 0 {
 		return "Administrator"
@@ -864,12 +864,12 @@ type data struct {
 	size  int64
 }
 
-// Retrieve all identities known to the Authenticator.
+// GetAuthenticatorIdentities retrieves all identities known to the Authenticator.
 func (x *Central) GetAuthenticatorIdentities(getIdentitiesFlag GetIdentitiesFlag) ([]AuthUser, error) {
 	return x.userStore.GetIdentities(getIdentitiesFlag)
 }
 
-// Retrieve the Role Group Database (which may be nil)
+// GetRoleGroupDB retrieves the Role Group Database (which may be nil)
 func (x *Central) GetRoleGroupDB() RoleGroupDB {
 	return x.roleGroupDB
 }

--- a/frontends.go
+++ b/frontends.go
@@ -13,7 +13,7 @@ var (
 	ErrHttpNotAuthorized = errors.New("No authorization information")
 )
 
-// Reads the session cookie or the HTTP "Basic" Authorization header to determine whether this request is authorized.
+// HttpHandlerPrelude reads the session cookie or the HTTP "Basic" Authorization header to determine whether this request is authorized.
 func HttpHandlerPrelude(config *ConfigHTTP, central *Central, r *http.Request) (*Token, error) {
 	sessioncookie, _ := r.Cookie(config.CookieName)
 	if sessioncookie != nil {
@@ -55,7 +55,7 @@ func HttpHandlerPreludeWithError(config *ConfigHTTP, central *Central, w http.Re
 	return token, err
 }
 
-// Handle the 'whoami' request, which is really just for debugging
+// HttpHandlerWhoAmI handles the 'whoami' request, which is really just for debugging
 func HttpHandlerWhoAmI(config *ConfigHTTP, central *Central, w http.ResponseWriter, r *http.Request) {
 	token, err := HttpHandlerPrelude(config, central, r)
 	if err != nil {
@@ -74,7 +74,7 @@ func HttpSendTxt(w http.ResponseWriter, responseCode int, responseBody string) {
 	fmt.Fprintf(w, "%v", responseBody)
 }
 
-// Handle the 'login' request, sending back a session token (via Set-Cookie),
+// HttpHandlerLogin handles the 'login' request, sending back a session token (via Set-Cookie),
 // if authentication succeeds. You may want to use this as a template to write your own.
 func HttpHandlerLogin(config *ConfigHTTP, central *Central, w http.ResponseWriter, r *http.Request) {
 	identity, password, basicOK := r.BasicAuth()

--- a/roledb.go
+++ b/roledb.go
@@ -28,7 +28,7 @@ type PermissionU16 uint16
 // A list of permissions
 type PermissionList []PermissionU16
 
-// Returns true if the list contains this permission
+// Has returns true if the list contains this permission
 func (x PermissionList) Has(perm PermissionU16) bool {
 	for _, bit := range x {
 		if bit == perm {
@@ -38,7 +38,7 @@ func (x PermissionList) Has(perm PermissionU16) bool {
 	return false
 }
 
-// Adds this permission to the list.
+// Add adds this permission to the list.
 // Takes no action if the permission is already present.
 func (x *PermissionList) Add(perm PermissionU16) {
 	for _, bit := range *x {
@@ -49,7 +49,7 @@ func (x *PermissionList) Add(perm PermissionU16) {
 	*x = append(*x, perm)
 }
 
-// Removes this permission from the lst
+// Remove removes this permission from the lst
 // Takes no action if the permission is not present.
 func (x *PermissionList) Remove(perm PermissionU16) {
 	for index, bit := range *x {
@@ -170,7 +170,7 @@ func EncodePermit(groupIds []GroupIDU32) []byte {
 	return res
 }
 
-// Decodes a Permit into a list of Group IDs
+// DecodePermit decodes a Permit into a list of Group IDs
 func DecodePermit(permit []byte) ([]GroupIDU32, error) {
 	if len(permit)%4 != 0 {
 		return nil, ErrPermitInvalid
@@ -430,7 +430,7 @@ func (x *sqlGroupDB) GetByID(id GroupIDU32) (*AuthGroup, error) {
 	return readSingleGroup(x.db.QueryRow("SELECT id,name,permlist FROM authgroup WHERE id = $1", id), fmt.Sprintf("%v", id))
 }
 
-// Add a new group. If the function is successful, then 'group.ID' will be set to the inserted record's ID
+// InsertGroup adds a new group. If the function is successful, then 'group.ID' will be set to the inserted record's ID
 func (x *sqlGroupDB) InsertGroup(group *AuthGroup) error {
 	if !GroupNameIsLegal(group.Name) {
 		return ErrGroupNameIllegal


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?