### PR TITLE
TI-3497: Fix for ldap user update loop

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -616,11 +616,7 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 			imqsUser, foundWithEmail = imqsUserEmailMap[CanonicalizeIdentity(ldapUser.Email)]
 		}
 		user := imqsUser
-		// We trim the spaces around the Email, as we have found that a certain
-		// ldap user (WilburGS) has an email that ends with a space. This space
-		// mysteriously dissapears when the address of `user` is taken which
-		// causes the user to be updated everytime as the email will never match
-		user.Email = strings.TrimSpace(ldapUser.Email)
+		user.Email = ldapUser.Email
 		user.Username = ldapUser.Username
 		user.Firstname = ldapUser.Firstname
 		user.Lastname = ldapUser.Lastname
@@ -630,6 +626,10 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 			user.Created = time.Now().UTC()
 			user.Modified = time.Now().UTC()
 
+			// WARNING: Weird compiler bug.
+			// We have found that a certain ldap user (WilburGS) has an email
+			// that ends with a space. This space mysteriously dissapears when
+			// the address of `user` is taken.
 			if _, err := x.userStore.CreateIdentity(&user, ""); err != nil {
 				x.Log.Warnf("LDAP merge: Create identity failed with (%v)", err)
 			}
@@ -644,6 +644,11 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 				x.Log.Infof("Updating user of Default user type, to LDAP user type: %v", imqsUser.Email)
 			}
 			user.Modified = time.Now().UTC()
+
+			// WARNING: Weird compiler bug.
+			// We have found that a certain ldap user (WilburGS) has an email
+			// that ends with a space. This space mysteriously dissapears when
+			// the address of `user` is taken.
 			if err := x.userStore.UpdateIdentity(&user); err != nil {
 				x.Log.Warnf("LDAP merge: Update identity failed with (%v)", err)
 			} else {

--- a/auth.go
+++ b/auth.go
@@ -628,7 +628,7 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 
 			// WARNING: Weird compiler bug.
 			// We have found that a certain ldap user (WilburGS) has an email
-			// that ends with a space. This space mysteriously dissapears when
+			// that ends with a space. This space mysteriously disappears when
 			// the address of `user` is taken.
 			if _, err := x.userStore.CreateIdentity(&user, ""); err != nil {
 				x.Log.Warnf("LDAP merge: Create identity failed with (%v)", err)
@@ -647,7 +647,7 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 
 			// WARNING: Weird compiler bug.
 			// We have found that a certain ldap user (WilburGS) has an email
-			// that ends with a space. This space mysteriously dissapears when
+			// that ends with a space. This space mysteriously disappears when
 			// the address of `user` is taken.
 			if err := x.userStore.UpdateIdentity(&user); err != nil {
 				x.Log.Warnf("LDAP merge: Update identity failed with (%v)", err)

--- a/auth.go
+++ b/auth.go
@@ -581,6 +581,11 @@ func userInfoToAuditTrailJSON(user AuthUser) string {
 	return string(contextData)
 }
 
+func userInfoToJSON(user AuthUser) string {
+	userJSON, _ := json.Marshal(user)
+	return string(userJSON)
+}
+
 // We are reading users from LDAP/AD and merging them into the IMQS userstore
 func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUsers []AuthUser) {
 	// Create maps from arrays
@@ -611,7 +616,11 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 			imqsUser, foundWithEmail = imqsUserEmailMap[CanonicalizeIdentity(ldapUser.Email)]
 		}
 		user := imqsUser
-		user.Email = ldapUser.Email
+		// We trim the spaces around the Email, as we have found that a certain
+		// ldap user (WilburGS) has an email that ends with a space. This space
+		// mysteriously dissapears when the address of `user` is taken which
+		// causes the user to be updated everytime as the email will never match
+		user.Email = strings.TrimSpace(ldapUser.Email)
 		user.Username = ldapUser.Username
 		user.Firstname = ldapUser.Firstname
 		user.Lastname = ldapUser.Lastname
@@ -630,14 +639,19 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 				contextData := userInfoToAuditTrailJSON(user)
 				x.Auditor.AuditUserAction(user.Username, "User Profile: "+user.Username, contextData, AuditActionCreated)
 			}
-		} else if foundWithEmail || !ldapUser.equals(imqsUser) {
+		} else if foundWithEmail || !user.equals(imqsUser) {
 			if imqsUser.Type == UserTypeDefault {
 				x.Log.Infof("Updating user of Default user type, to LDAP user type: %v", imqsUser.Email)
 			}
 			user.Modified = time.Now().UTC()
 			if err := x.userStore.UpdateIdentity(&user); err != nil {
 				x.Log.Warnf("LDAP merge: Update identity failed with (%v)", err)
+			} else {
+				x.Log.Infof("LDAP merge: Updated user %v", user.Username)
+				x.Log.Infof("old: %v", userInfoToJSON(imqsUser))
+				x.Log.Infof("new: %v", userInfoToJSON(user))
 			}
+
 			// Log to audit trail user updated
 			if x.Auditor != nil {
 				contextData := userInfoToAuditTrailJSON(user)
@@ -667,10 +681,11 @@ func (x *Central) MergeLdapUsersIntoLocalUserStore(ldapUsers []AuthUser, imqsUse
 }
 
 func (u AuthUser) equals(user AuthUser) bool {
-	if u.Email == user.Email && u.Firstname == user.Firstname && u.Lastname == user.Lastname && u.Mobilenumber == user.Mobilenumber && u.Username == user.Username {
-		return true
-	}
-	return false
+	return u.Email == user.Email &&
+		u.Firstname == user.Firstname &&
+		u.Lastname == user.Lastname &&
+		u.Mobilenumber == user.Mobilenumber &&
+		u.Username == user.Username
 }
 
 // Logout, which erases the session key

--- a/db.go
+++ b/db.go
@@ -118,21 +118,21 @@ type SessionDB interface {
 }
 
 type AuthUser struct {
-	UserId               UserId
-	Email                string
-	Username             string
-	Firstname            string
-	Lastname             string
-	Mobilenumber         string
-	Telephonenumber      string
-	Remarks              string
-	Created              time.Time
-	CreatedBy            UserId
-	Modified             time.Time
-	ModifiedBy           UserId
-	Type                 AuthUserType
-	Archived             bool
-	PasswordModifiedDate time.Time
+	UserId               UserId       `json:"userid"`
+	Email                string       `json:"email"`
+	Username             string       `json:"username"`
+	Firstname            string       `json:"firstname"`
+	Lastname             string       `json:"lastname"`
+	Mobilenumber         string       `json:"mobilenumber"`
+	Telephonenumber      string       `json:"telephonenumber`
+	Remarks              string       `json:"remarks"`
+	Created              time.Time    `json:"created"`
+	CreatedBy            UserId       `json:"createdby"`
+	Modified             time.Time    `json:"modified"`
+	ModifiedBy           UserId       `json:"modifiedby"`
+	Type                 AuthUserType `json:"type"`
+	Archived             bool         `json:"archived"`
+	PasswordModifiedDate time.Time    `json:"passwordmodifieddate"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/db.go
+++ b/db.go
@@ -118,21 +118,21 @@ type SessionDB interface {
 }
 
 type AuthUser struct {
-	UserId               UserId       `json:"userid"`
+	UserId               UserId       `json:"userID"`
 	Email                string       `json:"email"`
-	Username             string       `json:"username"`
-	Firstname            string       `json:"firstname"`
-	Lastname             string       `json:"lastname"`
-	Mobilenumber         string       `json:"mobilenumber"`
-	Telephonenumber      string       `json:"telephonenumber`
+	Username             string       `json:"userName"`
+	Firstname            string       `json:"firstName"`
+	Lastname             string       `json:"lastName"`
+	Mobilenumber         string       `json:"mobileNumber"`
+	Telephonenumber      string       `json:"telephoneNumber`
 	Remarks              string       `json:"remarks"`
 	Created              time.Time    `json:"created"`
-	CreatedBy            UserId       `json:"createdby"`
+	CreatedBy            UserId       `json:"createdBy"`
 	Modified             time.Time    `json:"modified"`
-	ModifiedBy           UserId       `json:"modifiedby"`
+	ModifiedBy           UserId       `json:"modifiedBy"`
 	Type                 AuthUserType `json:"type"`
 	Archived             bool         `json:"archived"`
-	PasswordModifiedDate time.Time    `json:"passwordmodifieddate"`
+	PasswordModifiedDate time.Time    `json:"passwordModifiedDate"`
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/db_sql.go
+++ b/db_sql.go
@@ -5,7 +5,6 @@ import (
 	"crypto/subtle"
 	"database/sql"
 	"encoding/base64"
-	//"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -353,7 +352,6 @@ func (x *sqlUserStoreDB) CreateIdentity(user *AuthUser, password string) (UserId
 }
 
 func (x *sqlUserStoreDB) UpdateIdentity(user *AuthUser) error {
-
 	err := x.checkIdentityExistsExcludingUserId(user.Email, user.Username, []UserId{user.UserId})
 	if err != nil {
 		return ErrIdentityExists
@@ -880,8 +878,8 @@ func createMigrations() []migration.Migrator {
 		`ALTER TABLE authuserstore ADD COLUMN authusertype SMALLINT default 0;`,
 
 		// 9. Additional data fields as well as fields to keep track of changes to users
-		`ALTER TABLE authuserstore 
-			ADD COLUMN phone VARCHAR, 
+		`ALTER TABLE authuserstore
+			ADD COLUMN phone VARCHAR,
 			ADD COLUMN remarks VARCHAR,
 			ADD COLUMN created TIMESTAMP,
 			ADD COLUMN createdby BIGINT,
@@ -889,9 +887,9 @@ func createMigrations() []migration.Migrator {
 			ADD COLUMN modifiedby BIGINT;`,
 
 		// 10. Archive passwords
-		`ALTER TABLE authuserstore  ALTER COLUMN modified SET DEFAULT NOW();	
+		`ALTER TABLE authuserstore  ALTER COLUMN modified SET DEFAULT NOW();
 		ALTER TABLE authuserpwd  ADD COLUMN created TIMESTAMP DEFAULT NOW();
-		ALTER TABLE authuserpwd  ADD COLUMN updated TIMESTAMP DEFAULT NOW();	
+		ALTER TABLE authuserpwd  ADD COLUMN updated TIMESTAMP DEFAULT NOW();
 
 		CREATE TABLE authpwdarchive (id BIGSERIAL PRIMARY KEY, userid BIGINT NOT NULL, password VARCHAR NOT NULL, created TIMESTAMP DEFAULT NOW());
 		`,

--- a/ldap.go
+++ b/ldap.go
@@ -88,11 +88,13 @@ func (x *LdapImpl) GetLdapUsers() ([]AuthUser, error) {
 	}
 	ldapUsers := make([]AuthUser, len(sr.Entries))
 	for i, value := range sr.Entries {
-		username := getAttributeValue(*value, "sAMAccountName")
-		name := getAttributeValue(*value, "givenName")
-		surname := getAttributeValue(*value, "sn")
-		email := getAttributeValue(*value, "mail")
-		mobile := getAttributeValue(*value, "mobile")
+		// We trim the spaces as we have found that a certain ldap user
+		// (WilburGS) has an email that ends with a space.
+		username := strings.TrimSpace(getAttributeValue(*value, "sAMAccountName"))
+		name := strings.TrimSpace(getAttributeValue(*value, "givenName"))
+		surname := strings.TrimSpace(getAttributeValue(*value, "sn"))
+		email := strings.TrimSpace(getAttributeValue(*value, "mail"))
+		mobile := strings.TrimSpace(getAttributeValue(*value, "mobile"))
 		ldapUsers[i] = AuthUser{UserId: NullUserId, Email: email, Username: username, Firstname: name, Lastname: surname, Mobilenumber: mobile}
 	}
 	return ldapUsers, nil


### PR DESCRIPTION
A ldap user with a space at the end of his email caused the system to update him
during every ldap merge as the space at the end of the email would mysteriously
dissapear after the user structs address was taken. We trim the spaces of the
emails now by default. Add exstra loging for ldap merge user update.