### PR TITLE
Fix for row scan failing on a null password

### DIFF
--- a/db_sql.go
+++ b/db_sql.go
@@ -59,13 +59,18 @@ func (x *sqlUserStoreDB) Authenticate(identity, password string, authTypeCheck A
 	}
 
 	row = x.db.QueryRow(`SELECT password, updated FROM authuserpwd WHERE userid = $1`, userId)
-	dbHash := ""
+	var dbHash sql.NullString
 	var lastUpdated time.Time
 	if err := row.Scan(&dbHash, &lastUpdated); err != nil {
 		return ErrIdentityAuthNotFound
 	}
 
-	if !verifyAuthausHash(password, dbHash) {
+	pHash := ""
+	if dbHash.Valid {
+		pHash = dbHash.String
+	}
+
+	if !verifyAuthausHash(password, pHash) {
 		return ErrInvalidPassword
 	}
 

--- a/db_sql.go
+++ b/db_sql.go
@@ -65,6 +65,9 @@ func (x *sqlUserStoreDB) Authenticate(identity, password string, authTypeCheck A
 		return ErrIdentityAuthNotFound
 	}
 
+	// The following step was added when we found some passwords being null.
+	// This happens when an ldap user is "migrated" to an IMQS user as we store
+	// the password for an ldap user as nil.
 	pHash := ""
 	if dbHash.Valid {
 		pHash = dbHash.String


### PR DESCRIPTION
This would return an ErrIdentityAuthNotFound which was missleading as the user
does indeed exsit at this point.