### PR TITLE
Add authuserstore db triggers. 

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## current
+
+## v1.0.27
+
+* fix: Add authuserstore db triggers. (ASG-2210)
+
+## v1.0.26
+
+* fix: passthrough auth session bug. (BAZ-202)
+
+## v1.0.25
+
+* Modified the MSAAD synchronisation process to set blank usernames for users in Auth to the email provided from AD.
+ 
+## v1.0.24
+
+* Deprecated

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,16 @@
 Authaus
 =======
 
+2023-03-06
+
+Introduced db triggers for the public.authuserstore db table within the auth db.
+
+These triggers will enforce the following. 
+
+created (timestamp) will now be set to NOW() on creation of a record by the trigger itself. created can also now not be modified on an update. 
+modified (timestamp) will now be set to NOW() on creation and and record update by the trigger itself.
+createdby (int) is now a mandatory field and the trigger wil raise in exception if it is not provided. createdby can also not be modified on any subsequent update. 
+
 Authaus is an authentication and authorization system written in Go.
 See the [documentation](http://godoc.org/github.com/IMQS/authaus) for more information.
 


### PR DESCRIPTION
fix: Add authuserstore db triggers. 

Add triggers to ensure that created, createdby and modified for the authuserstore table gets set correctly. 

- created - this gets set to NOW() when a record gets inserted. Once the record has been inserted this value should not change and the update trigger ensures this.
- createdby - if this value is null when a record gets inserted an exception will be raised. Once the record has been inserted this value should not change and the update trigger ensures this.
- modified - this value should always be set to NOW() whenever a record gets inserted or updated.
		
The naming convention used for the functions and triggers is as follows:
{database name}_{schema name}_{table name}_{type of trigger}

type of trigger:
- first character denoted when the action happens. 'b' for before, 'a' for after.
- second character denoted the type of action. 'i' for insert, 'u' for update.
- the last character just indicates that this is for a trigger and 't' is used.

Jira Ticket: ASG-2210