### PR TITLE
fix: Set Email and Username variables on the Token in CreateSession() 

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -593,10 +593,12 @@ func (x *Central) CreateSession(user *AuthUser, clientIPAddress, oauthSessionID 
 	}
 
 	token = &Token{
-		Permit:         *permit,
 		Identity:       user.getIdentity(),
 		UserId:         user.UserId,
+		Email:          user.Email,
+		Username:       user.Username,
 		InternalUUID:   user.InternalUUID,
+		Permit:         *permit,
 		OAuthSessionID: oauthSessionID,
 	}
 


### PR DESCRIPTION
Set the missing Email and Username variables on the `Token` that is created during the `CreateSession` function to fix the issue where tokens retrieved from cache contained empty Emails and Usernames.
