### PR TITLE
Add enabled and disabled audit user types

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -263,6 +263,8 @@ const (
 	AuditActionDeleted                        = "Deleted"
 	AuditActionResetPassword                  = "Reset Password"
 	AuditActionFailedLogin                    = "Failed Login"
+	AuditActionEnabled                        = "Enabled"
+	AuditActionDisabled                       = "Disabled"
 	AuditActionUnlocked                       = "User Account Unlocked"
 	AuditActionLocked                         = "User Account Locked"
 	AuditActionRestored                       = "Restored"


### PR DESCRIPTION
Create a special use case for the adding and removing of the ‘enabled’ permission. Add two new action types: Disabled: User Profile and Enabled: User Profile to the audit trail.

refs: NEXUS-4244